### PR TITLE
Better Liquidity Management

### DIFF
--- a/src/ape-together/ApeRebalanceExtension.sol
+++ b/src/ape-together/ApeRebalanceExtension.sol
@@ -7,6 +7,9 @@ import "indexcoop/contracts/interfaces/IBaseManager.sol";
 import "indexcoop/contracts/interfaces/IGeneralIndexModule.sol";
 import "indexcoop/contracts/lib/PreciseUnitMath.sol";
 
+import "setprotocol/contracts/interfaces/external/IUniswapV2Router.sol";
+import "setprotocol/contracts/interfaces/external/IUniswapV2Factory.sol";
+
 import "@openzeppelin/contracts/utils/SafeCast.sol";
 import "@openzeppelin/contracts/math/Math.sol";
 
@@ -24,13 +27,7 @@ import "./OwlNFT.sol";
 contract ApeRebalanceExtension is GIMExtension {
     using PreciseUnitMath for uint256;
     using SafeCast for uint256;
-
-    /* =========== Modifiers =========== */
-
-    modifier onlyEngineer() {
-        require(msg.sender == engineer, "only our supreme engineering overlords may call");
-        _;
-    }
+    using SafeCast for int256;
 
     /* ========== State Variables ======== */
 
@@ -41,11 +38,16 @@ contract ApeRebalanceExtension is GIMExtension {
     
     mapping(uint256 => uint256) public lastEpochVoted;
     mapping(address => uint256) public votes;
-    address[] public possibleComponents;
 
+    address[] public possibleComponents;
     uint256 public immutable maxComponents;
 
     OwlNFT public owlNft;
+
+    IUniswapV2Router public sushiRouter;
+    IUniswapV2Router public quickRouter;
+    IERC20 weth;
+    uint256 public minWethLiquidity;
 
     /* ========== Constructor ========== */
 
@@ -63,7 +65,10 @@ contract ApeRebalanceExtension is GIMExtension {
         IBaseManager _manager,
         IGeneralIndexModule _gim,
         OwlNFT _owlNft,
-        address _engineer,
+        IUniswapV2Router _sushiRouter,
+        IUniswapV2Router _quickRouter,
+        IERC20 _weth,
+        uint256 _minWethLiquidity,
         uint256 _startTime,
         uint256 _epochLength,
         uint256 _maxComponents
@@ -75,7 +80,10 @@ contract ApeRebalanceExtension is GIMExtension {
         currentEpochStart = _startTime;
         epochLength = _epochLength;
         maxComponents = _maxComponents;
-        engineer = _engineer;
+        sushiRouter = _sushiRouter;
+        quickRouter = _quickRouter;
+        weth = _weth;
+        minWethLiquidity = _minWethLiquidity;
     }
 
     /* ======== External Functions ======== */
@@ -95,6 +103,8 @@ contract ApeRebalanceExtension is GIMExtension {
         uint256 sumVotes;
         for (uint256 i = 0; i < _components.length; i++) {
             require(_votes[i] != 0, "no zero votes allowed");
+            require(_getBestWethLiquidityAmount(_components[i]) >= minWethLiquidity, "not enough liquidity");
+
             if (votes[_components[i]] == 0) {
                 possibleComponents.push(_components[i]);
             }
@@ -203,6 +213,36 @@ contract ApeRebalanceExtension is GIMExtension {
         return _getWeights();
     }
 
+    function isTokenLiquid(address _token) external view returns (bool) {
+        return _getBestWethLiquidityAmount(_token) >= minWethLiquidity;
+    }
+
+    function getTokenPrice(address _token) external view returns (uint256) {
+        return _getTokenPrice(_token);
+    }
+
+    function getSetPrice() external view returns (uint256) {
+        address[] memory components = setToken.getComponents();
+
+        uint256 sumValue;
+        for (uint256 i = 0; i < components.length; i++) {
+            uint256 units = setToken.getDefaultPositionRealUnit(components[i]).toUint256();
+            uint256 value = _getTokenPrice(components[i]).preciseMul(units);
+            sumValue = sumValue.add(value);
+        }
+
+        return sumValue;
+    }
+
+    function getRebalancePrices() external view returns (address[] memory components, uint256[] memory prices){
+        (components,) = _getWeights();
+
+        prices = new uint256[](components.length);
+        for (uint256 i = 0; i < components.length; i++) {
+            prices[i] = _getTokenPrice(components[i]);
+        }
+    }
+
     /* ========= Internal Functions ========== */
 
     /**
@@ -279,5 +319,34 @@ contract ApeRebalanceExtension is GIMExtension {
         for (uint256 i = 0; i < numComponents; i++) {
             weights[i] = finalVotes[i].preciseDiv(sumVotes);
         }
+    }
+
+    function _getBestRouter(address _token) internal view returns (IUniswapV2Router) {
+        uint256 sushiWethLiq = _getWethLiquidity(_token, sushiRouter);
+        uint256 quickWethLiq = _getWethLiquidity(_token, quickRouter);
+
+        return sushiWethLiq > quickWethLiq ? sushiRouter : quickRouter;
+    }
+
+    function _getBestWethLiquidityAmount(address _token) internal view returns (uint256) {
+        uint256 sushiWethLiq = _getWethLiquidity(_token, sushiRouter);
+        uint256 quickWethLiq = _getWethLiquidity(_token, quickRouter);
+
+        return Math.max(sushiWethLiq, quickWethLiq);
+    }
+
+    function _getWethLiquidity(address _token, IUniswapV2Router _router) internal view returns (uint256) {
+        address pair = IUniswapV2Factory(_router.factory()).getPair(address(weth), _token);
+        return weth.balanceOf(pair);
+    }
+
+    function _getTokenPrice(address _token) internal view returns (uint256) {
+        IUniswapV2Router router = _getBestRouter(_token);
+
+        address[] memory path = new address[](2);
+        path[0] = address(weth);
+        path[1] = _token;
+        
+        return uint(1).preciseDiv(router.getAmountsOut(1 ether, path)[1]);
     }
 }

--- a/src/ape-together/ApeRebalanceExtension.sol
+++ b/src/ape-together/ApeRebalanceExtension.sol
@@ -187,6 +187,10 @@ contract ApeRebalanceExtension is GIMExtension {
         delete possibleComponents;
     }
 
+    function setMinWethLiquidity(uint256 _newMin) external onlyOperator {
+        minWethLiquidity = _newMin;
+    }
+
     /**
      * Overrides the original rebalance function from GIMExtension. Always reverts.
      */
@@ -215,10 +219,6 @@ contract ApeRebalanceExtension is GIMExtension {
 
     function isTokenLiquid(address _token) external view returns (bool) {
         return _getBestWethLiquidityAmount(_token) >= minWethLiquidity;
-    }
-
-    function getTokenPrice(address _token) external view returns (uint256) {
-        return _getTokenPrice(_token);
     }
 
     function getSetPrice() external view returns (uint256) {

--- a/src/ape-together/ApeRebalanceExtension.sol
+++ b/src/ape-together/ApeRebalanceExtension.sol
@@ -31,8 +31,6 @@ contract ApeRebalanceExtension is GIMExtension {
 
     /* ========== State Variables ======== */
 
-    address public engineer;
-
     uint256 public epochLength;
     uint256 public  currentEpochStart;
     

--- a/src/ape-together/ApeRebalanceExtension.sol
+++ b/src/ape-together/ApeRebalanceExtension.sol
@@ -221,7 +221,7 @@ contract ApeRebalanceExtension is GIMExtension {
         return _getBestWethLiquidityAmount(_token) >= minWethLiquidity;
     }
 
-    function getSetPrice() external view returns (uint256) {
+    function getSetValue() external view returns (uint256) {
         address[] memory components = setToken.getComponents();
 
         uint256 sumValue;

--- a/src/mocks/UniFactoryMock.sol
+++ b/src/mocks/UniFactoryMock.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.10;
+
+contract UniFactoryMock {
+    address pair;
+
+    constructor(address _pair) public {
+        pair = _pair;
+    }
+
+    function getPair(address /* _token0 */, address /* _token1 */) external view returns (address) {
+        return pair;
+    }
+}

--- a/src/mocks/UniRouterMock.sol
+++ b/src/mocks/UniRouterMock.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.10;
+pragma experimental ABIEncoderV2;
+
+contract UniRouterMock {
+
+    uint256 amountOut;
+    address public factory;
+
+    constructor(uint256 _amountOut, address _factory) public {
+        amountOut = _amountOut;
+        factory = _factory;
+    }
+
+    function getAmountsOut(uint amountIn, address[] memory path) public view returns (uint[] memory amounts) {
+        amounts = new uint256[](path.length);
+        amounts[0] = amountIn;
+        amounts[path.length-1] = amountOut;
+    }
+}


### PR DESCRIPTION
Only allows tokens to be voted on that meet minimum liquidity requirements of Sushswap or Quickswap. Also adds some helper functions for checking whether the token has enough liquidity and for fetching the parameters of startRebalance.